### PR TITLE
chore: update rust_sdk

### DIFF
--- a/contract-rs/Cargo.toml
+++ b/contract-rs/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-near-sdk = { version = "5.0.0", features = ["legacy"] }
+near-sdk = { version = "5.1.0", features = ["legacy"] }
 
 [dev-dependencies]
 near-sdk = { version = "5.0.0", features = ["unit-testing"] }

--- a/contract-rs/src/lib.rs
+++ b/contract-rs/src/lib.rs
@@ -1,15 +1,11 @@
 // Find all our documentation at https://docs.near.org
-use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::collections::UnorderedMap;
-use near_sdk::{near_bindgen, AccountId, NearToken};
+use near_sdk::{near, AccountId, NearToken};
 
 mod donation;
 
 // Define the contract structure
-#[near_bindgen]
-#[derive(BorshDeserialize, BorshSerialize)]
-#[borsh(crate = "near_sdk::borsh")]
-
+#[near(contract_state)]
 pub struct Contract {
     pub beneficiary: AccountId,
     pub donations: UnorderedMap<AccountId, NearToken>,
@@ -26,7 +22,7 @@ impl Default for Contract {
 }
 
 // Implement the contract structure
-#[near_bindgen]
+#[near]
 impl Contract {
     // Public Method - but only callable by env::current_account_id()
     // initializes the contract with a beneficiary


### PR DESCRIPTION
updates rust sdk to 5.1 making use of #[near] and #[near(contract_state)]